### PR TITLE
build: Add a minimal GitHub Actions workflow

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,33 @@
+name: Python package
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - 3.8
+          - 3.9
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+      with:
+        # Checkout a pull request's HEAD commit instead of the merge
+        # commit, so that gitlint lints the correct commit message.
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      # TODO: replace this with just "tox" once everything is in place
+      # for the full test suite.
+      run: tox -e gitlint


### PR DESCRIPTION
For the time being, only invoke the `gitlint` testenv. Once the whole
plugin is in place and the full test suite has a chance to pass,
the `tox -e gitlint` invocation should be replaced with just `tox`.
