### PR TITLE
feat: Add support for Tutor 18 / Open edX Redwood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+-----------------------------
+
+* Support Tutor 18 and Open edX Redwood.
+
 Version 1.3.0 (2024-04-05)
 -----------------------------
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ appropriate one:
 | Olive            | `>=15.0, <16`     | `main`        | 1.x.x          |
 | Palm             | `>=16.0, <17`     | `main`        | 1.x.x          |
 | Quince           | `>=17.0, <18`     | `main`        | 1.x.x          |
+| Redwood          | `>=18.0, <19`     | `main`        | 1.x.x          |
 
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.7",
-    install_requires=["tutor <18, >=15.0"],
+    install_requires=["tutor <19, >=15.0"],
     setup_requires=['setuptools-scm<7'],
     entry_points={
         "tutor.plugin.v1": [


### PR DESCRIPTION
* Update the install_requires list to support Tutor 18.
* Update the compatibility matrix in the README accordingly.