### PR TITLE
docs: Update README and CHANGELOG to mention repo move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------------------------
+
+* Point release to mark the GitHub repository move.
+
 Version 2.2.0 (2025-07-28)
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This is an **experimental** plugin for
 [Tutor](https://docs.tutor.overhang.io) that configures access to a 
 private container image registry in a Kubernetes namespace.
 
+This repository was previously hosted under the `hastexo` GitHub organization, and moved to `cleura` in December 2025 as part of a routine repository consolidation.
+
 Version compatibility matrix
 ----------------------------
 
@@ -26,7 +28,7 @@ appropriate one:
 Installation
 ------------
 
-    pip install git+https://github.com/hastexo/tutor-contrib-registry@v2.2.0
+    pip install git+https://github.com/cleura/tutor-contrib-registry@v2.2.0
 
 Usage
 -----

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@ def load_readme():
 setup(
     name="tutor-contrib-registry",
     use_scm_version=True,
-    url="https://github.com/hastexo/tutor-contrib-registry",
+    url="https://github.com/cleura/tutor-contrib-registry",
     project_urls={
-        "Code": "https://github.com/hastexo/tutor-contrib-registry",
-        "Issue tracker": "https://github.com/hastexo/tutor-contrib-registry/issues", # noqa
+        "Code": "https://github.com/cleura/tutor-contrib-registry",
+        "Issue tracker": "https://github.com/cleura/tutor-contrib-registry/issues", # noqa
     },
     license="AGPLv3",
     author="Maari Tamm",


### PR DESCRIPTION
Mention that the repo has been moved from the hastexo to the cleura org.